### PR TITLE
Table view bug

### DIFF
--- a/ETAMock/JSONfetcher.swift
+++ b/ETAMock/JSONfetcher.swift
@@ -10,7 +10,6 @@ import Foundation
 
 class JSONfetcher {
     var url:URL?
-    var session:URLSession?
     var apiUrl:String?
 
     func getSourceUrl(apiUrl:String) -> URL {
@@ -23,14 +22,15 @@ class JSONfetcher {
     /// - Parameter url:        A Url object we want data from
     /// - Parameter completion: A closure which is called with the data
     func callApi(url:URL, completion: @escaping (String) -> ()) {
-        session = URLSession(configuration: .default)
-        var outputdata:String = ""
-        let task = session?.dataTask(with: url as URL) { (data, _, _) -> Void in
-            if let data = data {
-                outputdata = String(data: data, encoding: String.Encoding.utf8)!
+        URLSession.shared.dataTask(with: url, completionHandler: { (data, request, error) in
+            DispatchQueue.main.async(){
+                guard let data = data,
+                    let outputdata = String(data: data, encoding: String.Encoding.utf8) else {
+                    completion("")
+                    return
+                }
                 completion(outputdata)
             }
-        }
-        task?.resume()
+        }).resume()
     }
 }

--- a/ETAMock/RouteTableViewController.swift
+++ b/ETAMock/RouteTableViewController.swift
@@ -15,8 +15,8 @@ class RouteTableViewController: UITableViewController {
     var companyIndex = -1
     var urlString:String = ""
 
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
+    override func viewDidLoad() {
+        super.viewDidLoad()
         
         //Fetch
         urlString = "http://ec2-204-236-211-33.compute-1.amazonaws.com:8080/companies/\(companyIndex)/routes"
@@ -33,10 +33,6 @@ class RouteTableViewController: UITableViewController {
             //Reload the tableview
             self.tableView.reloadData()
         }
-    }
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
     }
 
     override func didReceiveMemoryWarning() {

--- a/ETAMock/StopsViewController.swift
+++ b/ETAMock/StopsViewController.swift
@@ -19,14 +19,11 @@ class StopsViewController: UIViewController, UITableViewDataSource, UITableViewD
     var urlString:String = ""
     let urlStringSouth:String = ""
     
-    override func viewWillAppear(_ animated: Bool) {
+    override func viewDidLoad() {
+        super.viewDidLoad()
         segmentButton.setTitle(route.direction1, forSegmentAt: 0)
         segmentButton.setTitle(route.direction2, forSegmentAt: 1)
         selectDirection(direction: route.direction1)
-    }
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
     }
 
     override func didReceiveMemoryWarning() {

--- a/ETAMockTests/GeneratedMocks.swift
+++ b/ETAMockTests/GeneratedMocks.swift
@@ -1,4 +1,4 @@
-// MARK: - Mocks generated from file: ETAMock/JSONFetcher.swift at 2017-03-28 23:39:22 +0000
+// MARK: - Mocks generated from file: ETAMock/JSONFetcher.swift at 2017-03-31 15:26:29 +0000
 
 //
 //  JSONfetcher.swift
@@ -35,15 +35,6 @@ class MockJSONfetcher: JSONfetcher, Cuckoo.Mock {
         }
     }
     
-    override var session: URLSession? {
-        get {
-            return manager.getter("session", original: observed.map { o in return { () -> URLSession? in o.session } })
-        }
-        set {
-            manager.setter("session", value: newValue, original: observed != nil ? { self.observed?.session = $0 } : nil)
-        }
-    }
-    
     override var apiUrl: String? {
         get {
             return manager.getter("apiUrl", original: observed.map { o in return { () -> String? in o.apiUrl } })
@@ -70,10 +61,6 @@ class MockJSONfetcher: JSONfetcher, Cuckoo.Mock {
         
         var url: Cuckoo.ToBeStubbedProperty<URL?> {
             return Cuckoo.ToBeStubbedProperty(manager: manager, name: "url")
-        }
-        
-        var session: Cuckoo.ToBeStubbedProperty<URLSession?> {
-            return Cuckoo.ToBeStubbedProperty(manager: manager, name: "session")
         }
         
         var apiUrl: Cuckoo.ToBeStubbedProperty<String?> {
@@ -106,10 +93,6 @@ class MockJSONfetcher: JSONfetcher, Cuckoo.Mock {
             return Cuckoo.VerifyProperty(manager: manager, name: "url", callMatcher: callMatcher, sourceLocation: sourceLocation)
         }
         
-        var session: Cuckoo.VerifyProperty<URLSession?> {
-            return Cuckoo.VerifyProperty(manager: manager, name: "session", callMatcher: callMatcher, sourceLocation: sourceLocation)
-        }
-        
         var apiUrl: Cuckoo.VerifyProperty<String?> {
             return Cuckoo.VerifyProperty(manager: manager, name: "apiUrl", callMatcher: callMatcher, sourceLocation: sourceLocation)
         }
@@ -133,14 +116,6 @@ class JSONfetcherStub: JSONfetcher {
     override var url: URL? {
         get {
             return DefaultValueRegistry.defaultValue(for: (URL?).self)
-        }
-        set {
-        }
-    }
-    
-    override var session: URLSession? {
-        get {
-            return DefaultValueRegistry.defaultValue(for: (URLSession?).self)
         }
         set {
         }


### PR DESCRIPTION
- API request needed to run on another thread.
- The table view needed to be setup in `viewDidLoad`, not in `viewWillAppear`. `viewWillAppear` is called whenever the view becomes visible again.